### PR TITLE
Use changelog file for package data

### DIFF
--- a/cryptodev-linux/version.sh
+++ b/cryptodev-linux/version.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 export git_repo="https://github.com/cryptodev-linux/cryptodev-linux.git"
-export package_name="cryptodev-linux"
-export package_version="1.13"
-export package_full="${package_name}-${package_version}"
 export custom_build=false
 export require_root=false
 export last_tested_commit="bb8bc7cf60d2c0b097c8b3b0e807f805b577a53f"

--- a/k3conf/suite/bookworm/debian/changelog
+++ b/k3conf/suite/bookworm/debian/changelog
@@ -1,3 +1,11 @@
+k3conf (0.2+git20230830+859e1cc-1) UNRELEASED; urgency=low
+
+  * New upstream release.
+  * Add cmake dependency for latest upstream
+  * Remove trailing spaces and extra newlines
+
+ -- Andrew Davis <afd@ti.com>  Thu, 31 Aug 2023 10:24:24 -0500
+
 k3conf (0.2.53-1) UNRELEASED; urgency=low
 
   * New upstream release.

--- a/k3conf/suite/bookworm/debian/control
+++ b/k3conf/suite/bookworm/debian/control
@@ -2,7 +2,7 @@ Source: k3conf
 Section: devel
 Priority: optional
 Maintainer: Suhaas Joshi <s-joshi@ti.com>
-Build-Depends: debhelper-compat (= 13)
+Build-Depends: debhelper-compat (= 13), cmake
 Standards-Version: 4.5.0
 Homepage: https://git.ti.com/cgit/k3conf/k3conf
 
@@ -10,7 +10,7 @@ Package: k3conf
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Powerful Diagnostic Tool for Texas Instruments K3 based Processors
- K3CONF is a Linux user-space application designed to provide a quick'n easy way 
- to dynamically diagnose Texas Instruments' K3 architecture based processors. 
- k3conf is intended to provide a similar experience to that of OMAPCONF that 
+ K3CONF is a Linux user-space application designed to provide a quick'n easy way
+ to dynamically diagnose Texas Instruments' K3 architecture based processors.
+ k3conf is intended to provide a similar experience to that of OMAPCONF that
  runs on legacy TI platforms.

--- a/k3conf/suite/bookworm/debian/rules
+++ b/k3conf/suite/bookworm/debian/rules
@@ -1,5 +1,4 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@  
-
+	dh $@

--- a/k3conf/version.sh
+++ b/k3conf/version.sh
@@ -3,4 +3,3 @@
 export git_repo="https://git.ti.com/git/k3conf/k3conf.git"
 export custom_build=false
 export require_root=false
-export last_tested_commit="81581afb405085755aea7744c1d196533e8094c4"

--- a/k3conf/version.sh
+++ b/k3conf/version.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 export git_repo="https://git.ti.com/git/k3conf/k3conf.git"
-export package_name="k3conf"
-export package_version="0.2.53"
-export package_full="${package_name}-${package_version}"
 export custom_build=false
 export require_root=false
 export last_tested_commit="81581afb405085755aea7744c1d196533e8094c4"

--- a/pru-pssp/version.sh
+++ b/pru-pssp/version.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 export git_repo="https://git.ti.com/git/pru-software-support-package/pru-software-support-package.git"
-export package_name="pru-pssp"
-export package_version="6.1"
-export package_full="${package_name}-${package_version}"
 export custom_build=false
 export require_root=true
 export last_tested_commit="75e974590eac2e38b53686e97018c47fc1147042"

--- a/run.sh
+++ b/run.sh
@@ -54,6 +54,7 @@ if [ ! -f "${builddir}/${package_full_ll}.orig.tar.gz" ]; then
     fi
     git -C "${sourcedir}/${package_name}" checkout "${last_tested_commit}"
     tar -cvzf "${builddir}/${package_full_ll}.orig.tar.gz" \
+      --exclude-vcs \
       --absolute-names "${sourcedir}/${package_name}" \
       --transform "s,${sourcedir}/${package_name},${package_full},"
 fi

--- a/run.sh
+++ b/run.sh
@@ -52,8 +52,9 @@ if [ ! -f "${package_full_ll}.orig.tar.gz" ]; then
     tar -cvzf "${builddir}/${package_full_ll}.orig.tar.gz" \
       --absolute-names "${sourcedir}/${package_name}" \
       --transform "s,${sourcedir}/${package_name},${package_full},"
-    tar -xzmf "${package_full_ll}.orig.tar.gz"
 fi
+
+tar -xzmf "${package_full_ll}.orig.tar.gz"
 
 cd "${builddir}/${package_full}"
 if [ ! -d "debian" ]; then

--- a/run.sh
+++ b/run.sh
@@ -17,14 +17,12 @@ if [ ! -d ${projdir} ]; then
     exit 1
 fi
 
-cd ${projdir}/suite/bookworm/
-package_name=$(dpkg-parsechangelog --show-field Source)
-deb_version=$(dpkg-parsechangelog --show-field Version)
+package_name=$(cd ${projdir}/suite/bookworm/ && dpkg-parsechangelog --show-field Source)
+deb_version=$(cd ${projdir}/suite/bookworm/ && dpkg-parsechangelog --show-field Version)
 package_version=$(echo $deb_version | cut -d'-' -f1)
 package_full="${package_name}-${package_version}"
 package_full_ll="${package_name}_${package_version}"
 echo "Building " $package_name " version " $deb_version
-cd -
 
 source ${projdir}/version.sh
 
@@ -43,8 +41,8 @@ fi
 
 mkdir -p "${sourcedir}"
 
-cd ${builddir}
-if [ ! -f "${package_full_ll}.orig.tar.gz" ]; then
+# Generate original source tarball if none found
+if [ ! -f "${builddir}/${package_full_ll}.orig.tar.gz" ]; then
     if [ ! -d "${sourcedir}/${package_name}" ]; then
         git clone "${git_repo}" "${sourcedir}/${package_name}"
     fi
@@ -54,11 +52,12 @@ if [ ! -f "${package_full_ll}.orig.tar.gz" ]; then
       --transform "s,${sourcedir}/${package_name},${package_full},"
 fi
 
-tar -xzmf "${package_full_ll}.orig.tar.gz"
+# Extract original source tarball
+tar -xzmf "${builddir}/${package_full_ll}.orig.tar.gz" -C "${builddir}"
 
-cd "${builddir}/${package_full}"
-if [ ! -d "debian" ]; then
-	debmake
+# Add default debian control files if none found
+if [ ! -d "${builddir}/${package_full}/debian" ]; then
+    (cd "${builddir}/${package_full}" && debmake)
 fi
 
 # Deploy our Debian control files
@@ -67,14 +66,12 @@ cp -rv "${projdir}/suite/bookworm/debian" "${builddir}/${package_full}/"
 run_prep
 
 # Build source package
-dpkg-source -b .
+(cd "${builddir}/${package_full}" && dpkg-source -b .)
 
 # Extract source package
-cd "${builddir}"
-if [ ! -d "${package_name}_${deb_version}" ]; then
-    dpkg-source -x "${package_name}_${deb_version}.dsc" "${package_name}_${deb_version}"
+if [ ! -d "${builddir}/${package_name}_${deb_version}" ]; then
+    dpkg-source -x "${builddir}/${package_name}_${deb_version}.dsc" "${builddir}/${package_name}_${deb_version}"
 fi
 
 # Build binary package
-cd "${package_name}_${deb_version}"
-debuild --no-lintian
+(cd "${builddir}/${package_name}_${deb_version}" && debuild --no-lintian)

--- a/run.sh
+++ b/run.sh
@@ -22,6 +22,7 @@ package_name=$(dpkg-parsechangelog --show-field Source)
 deb_version=$(dpkg-parsechangelog --show-field Version)
 package_version=$(echo $deb_version | cut -d'-' -f1)
 package_full="${package_name}-${package_version}"
+package_full_ll="${package_name}_${package_version}"
 echo "Building " $package_name " version " $deb_version
 cd -
 
@@ -43,7 +44,7 @@ fi
 mkdir -p "${sourcedir}"
 
 cd ${builddir}
-if [ ! -f "${package_full}.tar.gz" ]; then
+if [ ! -f "${package_full_ll}.orig.tar.gz" ]; then
     cd "${sourcedir}"
     if [ ! -d "${package_full}" ]; then
         git clone "${git_repo}" "${package_full}"
@@ -51,9 +52,9 @@ if [ ! -f "${package_full}.tar.gz" ]; then
     cd "${package_full}"
     git checkout "${last_tested_commit}"
     cd -
-    tar -cvzf "${builddir}/${package_full}.tar.gz" "${package_full}"
+    tar -cvzf "${builddir}/${package_full_ll}.orig.tar.gz" "${package_full}"
     cd ${builddir}
-    tar -xzmf "${package_full}.tar.gz"
+    tar -xzmf "${package_full_ll}.orig.tar.gz"
 fi
 
 cd "${builddir}/${package_full}"

--- a/run.sh
+++ b/run.sh
@@ -45,15 +45,13 @@ mkdir -p "${sourcedir}"
 
 cd ${builddir}
 if [ ! -f "${package_full_ll}.orig.tar.gz" ]; then
-    cd "${sourcedir}"
-    if [ ! -d "${package_full}" ]; then
-        git clone "${git_repo}" "${package_full}"
+    if [ ! -d "${sourcedir}/${package_name}" ]; then
+        git clone "${git_repo}" "${sourcedir}/${package_name}"
     fi
-    cd "${package_full}"
-    git checkout "${last_tested_commit}"
-    cd -
-    tar -cvzf "${builddir}/${package_full_ll}.orig.tar.gz" "${package_full}"
-    cd ${builddir}
+    git -C "${sourcedir}/${package_name}" checkout "${last_tested_commit}"
+    tar -cvzf "${builddir}/${package_full_ll}.orig.tar.gz" \
+      --absolute-names "${sourcedir}/${package_name}" \
+      --transform "s,${sourcedir}/${package_name},${package_full},"
     tar -xzmf "${package_full_ll}.orig.tar.gz"
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -25,6 +25,7 @@ fi
 package_name=$(cd ${debcontroldir} && dpkg-parsechangelog --show-field Source)
 deb_version=$(cd ${debcontroldir} && dpkg-parsechangelog --show-field Version)
 package_version=$(echo $deb_version | cut -d'-' -f1)
+last_tested_commit=$(echo $package_version | sed 's/.*+//')
 package_full="${package_name}-${package_version}"
 package_full_ll="${package_name}_${package_version}"
 echo "Building " $package_name " version " $deb_version

--- a/run.sh
+++ b/run.sh
@@ -6,10 +6,13 @@ if [ "$#" -eq 0 ]; then
     exit 1
 fi
 
+DEB_SUITE="${DEB_SUITE:-bookworm}"
+
 topdir=$(git rev-parse --show-toplevel)
 projdir="${topdir}/$1"
-builddir="${topdir}/build/$1"
-sourcedir="${builddir}/sources"
+sourcedir="${topdir}/build/sources"
+builddir="${topdir}/build/${DEB_SUITE}/$1"
+debcontroldir="${projdir}/suite/${DEB_SUITE}"
 
 if [ ! -d ${projdir} ]; then
     echo "This project does not exist."
@@ -17,8 +20,8 @@ if [ ! -d ${projdir} ]; then
     exit 1
 fi
 
-package_name=$(cd ${projdir}/suite/bookworm/ && dpkg-parsechangelog --show-field Source)
-deb_version=$(cd ${projdir}/suite/bookworm/ && dpkg-parsechangelog --show-field Version)
+package_name=$(cd ${debcontroldir} && dpkg-parsechangelog --show-field Source)
+deb_version=$(cd ${debcontroldir} && dpkg-parsechangelog --show-field Version)
 package_version=$(echo $deb_version | cut -d'-' -f1)
 package_full="${package_name}-${package_version}"
 package_full_ll="${package_name}_${package_version}"
@@ -61,7 +64,7 @@ if [ ! -d "${builddir}/${package_full}/debian" ]; then
 fi
 
 # Deploy our Debian control files
-cp -rv "${projdir}/suite/bookworm/debian" "${builddir}/${package_full}/"
+cp -rv "${debcontroldir}/debian" "${builddir}/${package_full}/"
 
 run_prep
 

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ "$#" -eq 0 ]; then
     echo "run.sh: missing operands"
     echo "Requires source package name as argument"
@@ -66,7 +68,7 @@ fi
 # Deploy our Debian control files
 cp -rv "${debcontroldir}/debian" "${builddir}/${package_full}/"
 
-run_prep
+run_prep || true
 
 # Build source package
 (cd "${builddir}/${package_full}" && dpkg-source -b .)

--- a/run.sh
+++ b/run.sh
@@ -67,16 +67,15 @@ cp -rv "${projdir}/suite/bookworm/debian" "${builddir}/${package_full}/"
 
 run_prep
 
-# Apply un-applied Debian patches
-patch_dir="${builddir}/${package_full}/debian/patches"
-while read -r patch; do
-    if [ -f "${builddir}/series" ]; then
-        if ! grep -Fxq "$patch" "${builddir}/series" ; then
-            continue
-        fi
-    fi
-    git apply --check "${patch_dir}/${patch}" --verbose --reject
-done < "${patch_dir}/series"
-cp "${patch_dir}/series" "${builddir}"
+# Build source package
+dpkg-source -b .
 
+# Extract source package
+cd "${builddir}"
+if [ ! -d "${package_name}_${deb_version}" ]; then
+    dpkg-source -x "${package_name}_${deb_version}.dsc" "${package_name}_${deb_version}"
+fi
+
+# Build binary package
+cd "${package_name}_${deb_version}"
 debuild --no-lintian

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,14 @@ if [ ! -d ${projdir} ]; then
     exit 1
 fi
 
+cd ${projdir}/suite/bookworm/
+package_name=$(dpkg-parsechangelog --show-field Source)
+deb_version=$(dpkg-parsechangelog --show-field Version)
+package_version=$(echo $deb_version | cut -d'-' -f1)
+package_full="${package_name}-${package_version}"
+echo "Building " $package_name " version " $deb_version
+cd -
+
 source ${projdir}/version.sh
 
 mkdir -p ${builddir}

--- a/ti-img-rogue-driver/version.sh
+++ b/ti-img-rogue-driver/version.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 export git_repo="https://git.ti.com/git/graphics/ti-img-rogue-driver.git"
-export package_name="ti-img-rogue-driver"
-export package_version="6.1"
-export package_full="${package_name}-${package_version}"
 export custom_build=false
 export require_root=false
 export last_tested_commit="ebddb087ef140ca83e4c30d66580b0bb33b003fd"

--- a/ti-linux-kernel/version.sh
+++ b/ti-linux-kernel/version.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 export git_repo="https://git.ti.com/git/ti-linux-kernel/ti-linux-kernel.git"
-export package_name="ti-linux-kernel"
-export package_version="6.1"
-export package_full="${package_name}-${package_version}"
 export custom_build=true
 export require_root=false
 export release_tag="09.00.00.006"

--- a/ti-rpmsg-char/suite/bookworm/debian/control
+++ b/ti-rpmsg-char/suite/bookworm/debian/control
@@ -9,7 +9,7 @@ Rules-Requires-Root: no
 
 Package: libti-rpmsg-char
 Section: libs
-Architecture: arm64
+Architecture: any
 Multi-Arch: same
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: RPMSG-char Utility Library
@@ -19,8 +19,7 @@ Description: RPMSG-char Utility Library
 
 Package: libti-rpmsg-char-dev
 Section: libdevel
-Architecture: arm64
-Multi-Arch: same
+Architecture: any
 Depends: libti-rpmsg-char
 Description: RPMSG-char Utility Library
  ti-rpmsg-char is a library designed to provide Linux applications an easy means

--- a/ti-rpmsg-char/version.sh
+++ b/ti-rpmsg-char/version.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 export git_repo="https://git.ti.com/git/rpmsg/ti-rpmsg-char.git"
-export package_name="ti-rpmsg-char"
-export package_version="0.3.0"
-export package_full="${package_name}-${package_version}"
 export custom_build=false
 export require_root=false
 export last_tested_commit="510e90d0a75bc21d79020669d2ea03f8222f3b8d"

--- a/wl18xx-ti-utils/version.sh
+++ b/wl18xx-ti-utils/version.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 export git_repo="https://git.ti.com/git/wilink8-wlan/18xx-ti-utils.git"
-export package_name="wl18xx-ti-utils"
-export package_version="0.8"
-export package_full="${package_name}-${package_version}"
 export custom_build=false
 export require_root=false
 export last_tested_commit="7325bf0b7b2d462e334437d2c7f9198d0ac55ce2"


### PR DESCRIPTION
We should use the debian/changelog file as the source for information on these packages. Do this and related cleanups.