### PR TITLE
pru-pssp: Fix and increase versioning

### DIFF
--- a/pru-pssp/suite/bookworm/debian/changelog
+++ b/pru-pssp/suite/bookworm/debian/changelog
@@ -1,3 +1,10 @@
+pru-pssp (6.3.0+git20240205+d09576fa-1) UNRELEASED; urgency=low
+
+  * New upstream release
+  * Fix versioning
+
+ -- Suhaas Joshi <s-joshi@ti.com>  Mon, 05 Feb 2024 14:30:00 +0000
+
 pru-pssp (6.1-1) UNRELEASED; urgency=low
 
   * Initial release.

--- a/pru-pssp/version.sh
+++ b/pru-pssp/version.sh
@@ -3,7 +3,6 @@
 export git_repo="https://git.ti.com/git/pru-software-support-package/pru-software-support-package.git"
 export custom_build=false
 export require_root=true
-export last_tested_commit="75e974590eac2e38b53686e97018c47fc1147042"
 
 function setup_cgt_pru() {
     cd ${builddir}


### PR DESCRIPTION
Also remove the "last_tested_commit" field from version.sh file. That is now obtained from the changelog file.