### PR TITLE
ti-img-rogue-umlibs: Move to https based URL

### DIFF
--- a/ti-img-rogue-umlibs/version.sh
+++ b/ti-img-rogue-umlibs/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-export git_repo="https://git.ti.com/cgit/graphics/ti-img-rogue-umlibs"
+export git_repo="https://git.ti.com/git/graphics/ti-img-rogue-umlibs.git"


### PR DESCRIPTION
cgit url uses http backend and doesn't allow shallow clone which is required for saving time while cloning.