### PR TITLE
ti-linux-kernel-rt: Update source package name

### DIFF
--- a/ti-linux-kernel-rt/suite/bookworm/debian/control
+++ b/ti-linux-kernel-rt/suite/bookworm/debian/control
@@ -1,4 +1,4 @@
-Source: ti-linux-kernel
+Source: ti-linux-kernel-rt
 Section: kernel
 Priority: optional
 Maintainer: Andrew Davis <afd@ti.com>


### PR DESCRIPTION
When building both ti-linux-kernel and ti-linux-kernel-rt packages, the source package name is causing a conflict.

Hence differentiate both by adding -rt suffix for RT Kernel package.