### PR TITLE
ti-linux-kernel(-rt): update changelog to 10.00.07

### DIFF
--- a/ti-linux-kernel-rt/suite/trixie/debian/changelog
+++ b/ti-linux-kernel-rt/suite/trixie/debian/changelog
@@ -1,3 +1,9 @@
+ti-linux-kernel (10.00.07-rt-1) trixie; urgency=medium
+
+  * New upstream release.
+
+ -- Suhaas Joshi <s-joshi@ti.com>  Mon, 12 Jul 2024 16:06:04 +0530
+
 ti-linux-kernel (10.00.04-rt-1) trixie; urgency=medium
 
   * New upstream release.

--- a/ti-linux-kernel/suite/trixie/debian/changelog
+++ b/ti-linux-kernel/suite/trixie/debian/changelog
@@ -1,3 +1,9 @@
+ti-linux-kernel (10.00.07-1) trixie; urgency=medium
+
+  * New upstream release.
+
+ -- Suhaas Joshi <s-joshi@ti.com>  Mon, 12 Jul 2024 16:06:04 +0530
+
 ti-linux-kernel (10.00.04-1) trixie; urgency=medium
 
   * New upstream release.


### PR DESCRIPTION
It looks like we missed updating the changelog during the 10.00 release. It is still at 10.00.04, while it should be 10.00.07. So make that update.

On ti-debpkgs, the kernel package is at the correct version. So this is the only change necessary.